### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const _    = require('underscore');
-const cld2 = require('./build/Release/cld');
+const cld2 = require('./build/Release/cld.node');
 
 module.exports = {
   LANGUAGES          : cld2.LANGUAGES,


### PR DESCRIPTION
Fix "Cannot find module './build/Release/cld' from 'node_modules/cld/index.js'".  Tested on node 16.13.0 and 18.12.1